### PR TITLE
Update build.zig.zon

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -5,7 +5,7 @@
     .dependencies = .{
         .@"tree-sitter" = .{
             .url = "https://github.com/ziglibs/tree-sitter/archive/1be7d7a849f9242d6a74e1836a1cac6deefb5f7d.tar.gz",
-            .hash = "1220cbcf9093838fa5e22cb939cc6f22ed203edbe0769a4650a8e819ed16c79640e2",
+            .hash = "122037f860c2db559f7619bc945ac7e8ce90f3ad1c4547807c7779d879285a9341b7",
         },
     },
 }


### PR DESCRIPTION
Hash was incorrect, this should be the correct hash


> Fetch Packages [2/3] treez.tree-sitter... /home/southporter/.cache/zig/p/122045a043ff06ec47ba5901460f658eb1c4be707c23c6950687ce0f282b9b388fbd/build.zig.zon:8:21: error: hash mismatch: expected: 1220cbcf9093838fa5e22cb939cc6f22ed203edbe0769a4650a8e819ed16c79640e2, found: 122037f860c2db559f7619bc945ac7e8ce90f3ad1c4547807c7779d879285a9341b7
            .hash = "1220cbcf9093838fa5e22cb939cc6f22ed203edbe0769a4650a8e819ed16c79640e2",
                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~