### PR TITLE
update to work on newest zig and tree-sitter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 staging
 zig-*
+.zig-cache/

--- a/build.zig
+++ b/build.zig
@@ -2,7 +2,7 @@ const std = @import("std");
 
 pub fn build(b: *std.Build) void {
     _ = b.addModule("treez", .{
-        .root_source_file = .{ .path = "treez.zig" },
+        .root_source_file = b.path("treez.zig"),
     });
 
     const target = b.standardTargetOptions(.{});
@@ -15,36 +15,39 @@ pub fn build(b: *std.Build) void {
 
     // Example
 
-    //     const exe = b.addExecutable(.{
-    //         .name = "treez-example",
-    //         // In this case the main source file is merely a path, however, in more
-    //         // complicated build scripts, this could be a generated file.
-    //         .root_source_file = .{ .path = "example.zig" },
-    //         .target = target,
-    //         .optimize = optimize,
-    //     });
+    // const exe = b.addExecutable(.{
+    //     .name = "treez-example",
+    //     // In this case the main source file is merely a path, however, in more
+    //     // complicated build scripts, this could be a generated file.
+    //     .root_source_file = b.path("example/example.zig"),
+    //     .target = target,
+    //     .optimize = optimize,
+    // });
 
-    //     exe.linkLibC();
+    // Added module import for example to use directly, requires changing _ = to const treez = at the top
+    // exe.root_module.addImport("treez", treez);
 
-    //     exe.linkLibrary(b.dependency("tree-sitter", .{
-    //         .target = target,
-    //         .optimize = optimize,
-    //     }).artifact("tree-sitter"));
+    // exe.linkLibC();
 
-    //     exe.linkLibrary(b.dependency("tree-sitter-zig", .{
-    //         .target = target,
-    //         .optimize = optimize,
-    //     }).artifact("tree-sitter-zig"));
+    // exe.linkLibrary(b.dependency("tree-sitter", .{
+    //     .target = target,
+    //     .optimize = optimize,
+    // }).artifact("tree-sitter"));
 
-    //     b.installArtifact(exe);
+    // exe.linkLibrary(b.dependency("tree-sitter-zig", .{
+    //     .target = target,
+    //     .optimize = optimize,
+    // }).artifact("tree-sitter-zig"));
 
-    //     const run_cmd = b.addRunArtifact(exe);
-    //     run_cmd.step.dependOn(b.getInstallStep());
+    // b.installArtifact(exe);
 
-    //     if (b.args) |args| {
-    //         run_cmd.addArgs(args);
-    //     }
+    // const run_cmd = b.addRunArtifact(exe);
+    // run_cmd.step.dependOn(b.getInstallStep());
 
-    //     const run_step = b.step("example", "Run the example");
-    //     run_step.dependOn(&run_cmd.step);
+    // if (b.args) |args| {
+    //     run_cmd.addArgs(args);
+    // }
+
+    // const run_step = b.step("example", "Run the example");
+    // run_step.dependOn(&run_cmd.step);
 }

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -4,8 +4,8 @@
 
     .dependencies = .{
         .@"tree-sitter" = .{
-            .url = "https://github.com/ziglibs/tree-sitter/archive/1be7d7a849f9242d6a74e1836a1cac6deefb5f7d.tar.gz",
-            .hash = "1220cbcf9093838fa5e22cb939cc6f22ed203edbe0769a4650a8e819ed16c79640e2",
+            .url = "https://github.com/tree-sitter/tree-sitter/archive/25c7189180849be27b1e552d27f0488e3bd5900d.tar.gz",
+            .hash = "122014699420476e54c5f4ce36bfd62d0871acd5b1355a0c5c8e94ad128576d953f8",
         },
     },
 

--- a/example/example.zig
+++ b/example/example.zig
@@ -1,7 +1,7 @@
 const std = @import("std");
-const treez = @import("../treez.zig");
+const treez = @import("treez");
 
-const log = std.log.scoped(.treesitter_ast)
+const log = std.log.scoped(.treesitter_ast);
 
 pub fn main() !void {
     const allocator = std.heap.page_allocator;


### PR DESCRIPTION
It looks like your changes were merged into [tree-sitter/tree-sitter](https://github.com/tree-sitter/tree-sitter/blob/master/build.zig), so I went ahead and moved over to that in `build.zig.zon`

I then updated build.zig to use newest zig syntax and cleaned up the example build and script to work with newest zig as well. 