### PR TITLE
Fix missing * typo in Parser.parse() declaration

### DIFF
--- a/treez.zig
+++ b/treez.zig
@@ -155,7 +155,7 @@ pub const Parser = opaque {
     }
 
     pub const ParseError = error{ NoLanguage, Unknown };
-    pub fn parse(parser: Parser, old_tree: ?*Tree, input: Input) ParseError!*Tree {
+    pub fn parse(parser: *Parser, old_tree: ?*Tree, input: Input) ParseError!*Tree {
         return if (externs.ts_parser_parse(parser, old_tree, input)) |tree|
             tree
         else


### PR DESCRIPTION
This must be a typo. Parser cannot be passed by value as it is an anyopaque. Also, it is a pointer in the C interface.